### PR TITLE
Implement SPI mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Matthias Weisser
 Tilman Sauerbeck
 Mateusz Spychała
 Ernst Schwab
+Nils Hasenbanck

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ OBJS =	dev_table.o	\
 	serial_common.o	\
 	serial_platform.o	\
 	stm32.o		\
+	spi.o		\
 	utils.o
 
 LIBOBJS = parsers/parsers.a

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,6 +15,7 @@ stm32flash_SOURCES  = \
 	serial_common.c	\
 	serial_platform.c\
 	stm32.c		\
+	spi.c		\
 	utils.c
 
 stm32flash_LDADD   = ${top_builddir}/parsers/parsers.la

--- a/i2c.c
+++ b/i2c.c
@@ -141,7 +141,7 @@ static port_err_t i2c_close(struct port_interface *port)
 }
 
 static port_err_t i2c_read(struct port_interface *port, void *buf,
-			   size_t nbyte)
+			   size_t nbyte, bool __unused isDataFrame)
 {
 	struct i2c_priv *h;
 	int ret;

--- a/init.c
+++ b/init.c
@@ -215,19 +215,19 @@ static int gpio_sequence(struct port_interface *port, const char *seq, size_t le
 			l -= 3;
 		} else if (*s && (l > 0)) {
 			delimiter = 1;
-			/* The ',' delimiter adds a 100 ms delay between signal toggles.
-			 * i.e -rts,dtr will reset rts, wait 100 ms, set dtr.
+			/* The ',' delimiter adds a 500 ms delay between signal toggles.
+			 * i.e -rts,dtr will reset rts, wait 500 ms, set dtr.
 			 *
 			 * The '&' delimiter adds no delay between signal toggles.
 			 * i.e -rts&dtr will reset rts and immediately set dtr.
 			 *
 			 * Example: -rts&dtr,,,rts,-dtr will reset rts and set dtr
-			 * without delay, then wait 300 ms, set rts, wait 100 ms, reset dtr.
+			 * without delay, then wait 1500 ms, set rts, wait 500 ms, reset dtr.
 			 */
 			if (*s == ',') {
 				s++;
 				l--;
-				sleep_time = 100000;
+				sleep_time = 500000;
 			} else if (*s == '&') {
 				s++;
 				l--;

--- a/main.c
+++ b/main.c
@@ -43,7 +43,7 @@
 #include <windows.h>
 #endif
 
-#define VERSION "STM32duino_0.5.1"
+#define VERSION "STM32duino_0.6.0"
 
 /* device globals */
 stm32_t		*stm		= NULL;

--- a/main.c
+++ b/main.c
@@ -878,7 +878,7 @@ int parse_options(int argc, char *argv[])
 
 void show_help(char *name) {
 	fprintf(stderr,
-		"Usage: %s [-bvngfhc] [-[rw] filename] [tty_device | i2c_device]\n"
+		"Usage: %s [-bvngfhc] [-[rw] filename] [tty_device | i2c_device | spi_device]\n"
 		"	-a bus_address	Bus address (e.g. for I2C port)\n"
 		"	-b rate		Baud rate (default 57600)\n"
 		"	-m mode		Serial port mode (default 8e1)\n"
@@ -922,6 +922,8 @@ void show_help(char *name) {
 		"		%s /dev/ttyS0\n"
 		"	  or:\n"
 		"		%s /dev/i2c-0\n"
+		"	  or:\n"
+		"		%s /dev/spidev0.0\n"
 		"\n"
 		"	Write with verify and then start execution:\n"
 		"		%s -w filename -v -g 0x0 /dev/ttyS0\n"
@@ -943,6 +945,7 @@ void show_help(char *name) {
 		"	- entry sequence: delay 500ms\n"
 		"	- exit sequence: rts=high, dtr=low, 300ms delay, GPIO_2=high\n"
 		"		%s -R -i ',,,,,:rts&-dtr,,,2' /dev/ttyS0\n",
+		name,
 		name,
 		name,
 		name,

--- a/port.c
+++ b/port.c
@@ -26,10 +26,12 @@
 
 extern struct port_interface port_serial;
 extern struct port_interface port_i2c;
+extern struct port_interface port_spi;
 
 static struct port_interface *ports[] = {
 	&port_serial,
 	&port_i2c,
+	&port_spi,
 	NULL,
 };
 

--- a/port.h
+++ b/port.h
@@ -31,9 +31,11 @@ typedef enum {
 /* flags */
 #define PORT_BYTE	(1 << 0)	/* byte (not frame) oriented */
 #define PORT_GVR_ETX	(1 << 1)	/* cmd GVR returns protection status */
-#define PORT_CMD_INIT	(1 << 2)	/* use INIT cmd to autodetect speed */
-#define PORT_RETRY	(1 << 3)	/* allowed read() retry after timeout */
-#define PORT_STRETCH_W	(1 << 4)	/* warning for no-stretching commands */
+#define PORT_UART_INIT	(1 << 2)	/* UART init needed */
+#define PORT_SPI_INIT	(1 << 3)	/* SPI init needed */
+#define PORT_RETRY	(1 << 4)	/* allowed read() retry after timeout */
+#define PORT_STRETCH_W	(1 << 5)	/* warning for no-stretching commands */
+#define PORT_CMD_SOF	(1 << 6)	/* cmd need SOF byte */
 
 /* all options and flags used to open and configure an interface */
 struct port_options {

--- a/port.h
+++ b/port.h
@@ -21,6 +21,8 @@
 #ifndef _H_PORT
 #define _H_PORT
 
+#include <stdbool.h>
+
 typedef enum {
 	PORT_ERR_OK = 0,
 	PORT_ERR_NODEV,		/* No such device */
@@ -65,7 +67,7 @@ struct port_interface {
 	port_err_t (*open)(struct port_interface *port, struct port_options *ops);
 	port_err_t (*close)(struct port_interface *port);
 	port_err_t (*flush)(struct port_interface *port);
-	port_err_t (*read)(struct port_interface *port, void *buf, size_t nbyte);
+	port_err_t (*read)(struct port_interface *port, void *buf, size_t nbyte, bool isDataFrame);
 	port_err_t (*write)(struct port_interface *port, void *buf, size_t nbyte);
 	port_err_t (*gpio)(struct port_interface *port, serial_gpio_t n, int level);
 	const char *(*get_cfg_str)(struct port_interface *port);

--- a/serial_posix.c
+++ b/serial_posix.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <sys/file.h>
 
+#include "compiler.h"
 #include "serial.h"
 #include "port.h"
 
@@ -268,7 +269,7 @@ static port_err_t serial_posix_close(struct port_interface *port)
 }
 
 static port_err_t serial_posix_read(struct port_interface *port, void *buf,
-				     size_t nbyte)
+				     size_t nbyte, bool __unused isDataFrame)
 {
 	serial_t *h;
 	ssize_t r;

--- a/serial_posix.c
+++ b/serial_posix.c
@@ -375,7 +375,7 @@ static port_err_t serial_posix_flush(struct port_interface *port)
 
 struct port_interface port_serial = {
 	.name	= "serial_posix",
-	.flags	= PORT_BYTE | PORT_GVR_ETX | PORT_CMD_INIT | PORT_RETRY,
+	.flags	= PORT_BYTE | PORT_UART_INIT | PORT_GVR_ETX | PORT_RETRY,
 	.open	= serial_posix_open,
 	.close	= serial_posix_close,
 	.flush  = serial_posix_flush,

--- a/serial_w32.c
+++ b/serial_w32.c
@@ -350,7 +350,7 @@ static port_err_t serial_w32_flush(struct port_interface *port)
 
 struct port_interface port_serial = {
 	.name	= "serial_w32",
-	.flags	= PORT_BYTE | PORT_GVR_ETX | PORT_CMD_INIT | PORT_RETRY,
+	.flags	= PORT_BYTE | PORT_UART_INIT | PORT_GVR_ETX | PORT_RETRY,
 	.open	= serial_w32_open,
 	.close	= serial_w32_close,
 	.flush  = serial_w32_flush,

--- a/serial_w32.c
+++ b/serial_w32.c
@@ -244,7 +244,7 @@ static port_err_t serial_w32_close(struct port_interface *port)
 }
 
 static port_err_t serial_w32_read(struct port_interface *port, void *buf,
-				  size_t nbyte)
+				  size_t nbyte, bool __unused isDataFrame)
 {
 	serial_t *h;
 	DWORD r;

--- a/spi.c
+++ b/spi.c
@@ -127,7 +127,7 @@ static port_err_t spi_open(struct port_interface *port,
     free(h);
     return PORT_ERR_UNKNOWN;
   }
-  
+
   h->fd = fd;
   port->private = h;
 
@@ -150,15 +150,15 @@ static port_err_t spiTransfer(struct spi_priv *h, void *data, size_t length) {
   int ret;
 
   struct spi_ioc_transfer tr = {
-    .tx_buf = (uint32_t)(data);
-    .rx_buf = (uint32_t)(data);
+    .tx_buf = (long int)(data),
+    .rx_buf = (long int)(data),
 		.len = sizeof(*(data)),
 		.speed_hz = 0,
 		.bits_per_word = 0,
     .delay_usecs = 0,
     .cs_change = false
   };
-  
+
   ret = ioctl(h->fd, SPI_IOC_MESSAGE(1), &tr) ;
   if(ret < 0) {
       fprintf(stderr, "Error while transfering data: %d\n", errno);
@@ -186,7 +186,7 @@ static port_err_t spi_read(struct port_interface *port, void *buf,
   ret = spiTransfer(h, buf, nbyte);
   if (ret != (int)nbyte)
     return PORT_ERR_UNKNOWN;
-  
+
   return PORT_ERR_OK;
 }
 

--- a/spi.c
+++ b/spi.c
@@ -152,26 +152,18 @@ static port_err_t spi_read(struct port_interface *port, void *buf,
          size_t nbyte) {
   struct spi_priv *h;
   int ret;
-  uint8_t dummy = 0x00;
   uint32_t retry = 0;
 
   h = (struct spi_priv *)port->private;
   if (h == NULL)
     return PORT_ERR_UNKNOWN;
 
-  struct spi_ioc_transfer tr[2] = {
-    {
-      .rx_buf = (long int)(&dummy),
-      .tx_buf = (long int)(&dummy),
-		  .len = 1,
-    },
-    {
+  struct spi_ioc_transfer tr = {
       .rx_buf = (long int)(buf),
 		  .len = nbyte,
-    }
   };
 
-  ret = ioctl(h->fd, SPI_IOC_MESSAGE(2), &tr) ;
+  ret = ioctl(h->fd, SPI_IOC_MESSAGE(1), &tr) ;
   if(ret < 0) {
     fprintf(stderr, "Error while reading data: %d\n", errno);
     return PORT_ERR_UNKNOWN;

--- a/spi.c
+++ b/spi.c
@@ -1,0 +1,237 @@
+/*
+  stm32flash - Open Source ST STM32 flash program for *nix
+  Copyright (C) 2014 Antonio Borneo <borneo.antonio@gmail.com>
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include "compiler.h"
+#include "serial.h"
+#include "port.h"
+
+
+#if !defined(__linux__)
+
+static port_err_t spi_open(struct port_interface __unused *port,
+         struct port_options __unused *ops)
+{
+  return PORT_ERR_NODEV;
+}
+
+struct port_interface port_spi = {
+  .name	= "spi",
+  .open	= spi_open,
+};
+
+#else
+
+#include <linux/spi/spidev.h>
+#include <sys/ioctl.h>
+
+struct spi_priv {
+  int fd;
+  uint8_t mode;
+  uint8_t bits;
+  uint32_t speed;
+};
+
+static port_err_t spi_open(struct port_interface *port,
+         struct port_options *ops) {
+  struct spi_priv *h;
+  int fd, ret;
+
+  /* 1. check device name match */
+  if (strncmp(ops->device, "/dev/spidev", strlen("/dev/spidev")))
+    return PORT_ERR_NODEV;
+
+  /* 2. open it device file */
+  h = calloc(sizeof(*h), 1);
+  if (h == NULL) {
+    fprintf(stderr, "Out of memory\n");
+    return PORT_ERR_UNKNOWN;
+  }
+  fd = open(ops->device, O_RDWR);
+  if (fd < 0) {
+    fprintf(stderr, "Unable to open device \"%s\"\n", ops->device);
+    free(h);
+    return PORT_ERR_UNKNOWN;
+  }
+
+  /* 3. configure the SPI device */
+  h->mode = 0;
+  h->bits = 8;
+  h->speed = 8000000; // 8 Mhz
+
+  ret = ioctl(fd, SPI_IOC_WR_MODE, &h->mode);
+  if (ret < 0) {
+    fprintf(stderr, "Error while setting spi mode: %d\n", errno);
+    close(fd);
+    free(h);
+    return PORT_ERR_UNKNOWN;
+    }
+  ret = ioctl(fd, SPI_IOC_RD_MODE, &h->mode);
+  if (ret < 0) {
+    fprintf(stderr, "Error while verifying spi mode: %d\n", errno);
+    close(fd);
+    free(h);
+    return PORT_ERR_UNKNOWN;
+    }
+  ret = ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, &h->bits);
+  if (ret < 0) {
+    fprintf(stderr, "Error while setting bits per word: %d\n", errno);
+    close(fd);
+    free(h);
+    return PORT_ERR_UNKNOWN;
+    }
+  ret = ioctl(fd, SPI_IOC_RD_BITS_PER_WORD, &h->bits);
+  if (ret < 0) {
+    fprintf(stderr, "Error while verifying bits per word: %d\n", errno);
+    close(fd);
+    free(h);
+    return PORT_ERR_UNKNOWN;
+    }
+  ret = ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &h->speed);
+  if (ret < 0) {
+    fprintf(stderr, "Error while setting bus speed: %d\n", errno);
+    close(fd);
+    free(h);
+    return PORT_ERR_UNKNOWN;
+    }
+  ret = ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, &h->speed);
+  if (ret < 0) {
+    fprintf(stderr, "Error while verifying bus speed: %d\n", errno);
+    close(fd);
+    free(h);
+    return PORT_ERR_UNKNOWN;
+    }
+
+  /* Kontrollausgabe */
+  printf("SPI-Device.....: %s\n", ops->device);
+  printf("SPI-Mode.......: %d\n", h->mode);
+  printf("Bit per word...: %d\n", h->bits);
+  printf("Speed..........: %d kHz (%d MHz)\n", h->speed/1000, h->speed/1000/1000);
+
+  h->fd = fd;
+  port->private = h;
+  return PORT_ERR_OK;
+}
+
+static port_err_t spi_close(struct port_interface *port) {
+  struct spi_priv *h;
+
+  h = (struct spi_priv *)port->private;
+  if (h == NULL)
+    return PORT_ERR_UNKNOWN;
+  close(h->fd);
+  free(h);
+  port->private = NULL;
+  return PORT_ERR_OK;
+}
+
+static port_err_t spiWriteRead(struct spi_priv *h, void *data, size_t length) {
+  struct spi_ioc_transfer spi[length];
+  int i, ret;
+
+  for (i = 0; i < length; i++) {
+    spi[i].tx_buf        = (unsigned long)(data + i);
+    spi[i].rx_buf        = (unsigned long)(data + i);
+    spi[i].len           = sizeof(*(data + i));
+    spi[i].delay_usecs   = 0;
+    spi[i].speed_hz      = h->speed;
+    spi[i].bits_per_word = h->bits;
+    spi[i].cs_change     = 0;
+  }
+
+  ret = ioctl(h->fd, SPI_IOC_MESSAGE(length), &spi) ;
+  if(ret < 0) {
+    fprintf(stderr, "Error while transfering data: %d\n", errno);
+    return PORT_ERR_UNKNOWN;
+  }
+  return ret;
+}
+
+static port_err_t spi_read(struct port_interface *port, void *buf,
+         size_t nbyte) {
+  struct spi_priv *h;
+  int ret;
+
+  h = (struct spi_priv *)port->private;
+  if (h == NULL)
+    return PORT_ERR_UNKNOWN;
+  ret = spiWriteRead(h, buf, nbyte);
+  if (ret != (int)nbyte)
+    return PORT_ERR_UNKNOWN;
+  return PORT_ERR_OK;
+}
+
+static port_err_t spi_write(struct port_interface *port, void *buf,
+          size_t nbyte) {
+  struct spi_priv *h;
+  int ret;
+
+  h = (struct spi_priv *)port->private;
+  if (h == NULL)
+    return PORT_ERR_UNKNOWN;
+  ret = spiWriteRead(h, buf, nbyte);
+  if (ret != (int)nbyte)
+    return PORT_ERR_UNKNOWN;
+  return PORT_ERR_OK;
+}
+
+static port_err_t spi_gpio(struct port_interface __unused *port,
+         serial_gpio_t __unused n, int __unused level) {
+  return PORT_ERR_OK;
+}
+
+static const char *spi_get_cfg_str(struct port_interface *port) {
+  return "NO CONFIG";
+}
+
+static struct varlen_cmd spi_cmd_get_reply[] = {
+  {0x10, 11},
+  {0x11, 11},
+  { /* empty */ }
+};
+
+static port_err_t spi_flush(struct port_interface __unused *port) {
+  /* We shouldn't need to flush spi */
+  return PORT_ERR_OK;
+}
+
+struct port_interface port_spi = {
+  .name	= "spi",
+  .flags	= PORT_STRETCH_W,
+  .open	= spi_open,
+  .close	= spi_close,
+  .flush  = spi_flush,
+  .read	= spi_read,
+  .write	= spi_write,
+  .gpio	= spi_gpio,
+  .cmd_get_reply	= spi_cmd_get_reply,
+  .get_cfg_str	= spi_get_cfg_str,
+};
+
+#endif

--- a/spi.c
+++ b/spi.c
@@ -128,7 +128,6 @@ static port_err_t spi_open(struct port_interface *port,
     return PORT_ERR_UNKNOWN;
     }
 
-  /* Kontrollausgabe */
   printf("SPI-Device.....: %s\n", ops->device);
   printf("SPI-Mode.......: %d\n", h->mode);
   printf("Bit per word...: %d\n", h->bits);

--- a/spi.c
+++ b/spi.c
@@ -177,7 +177,7 @@ static port_err_t spi_read(struct port_interface *port, void *buf,
     return PORT_ERR_UNKNOWN;
 
   // Send dummy data to initiate read
-  int tmp = 0xFE;
+  int tmp = 0x00;
   ret = spiTransfer(h, &tmp, 1);
   if (ret != (int)nbyte)
     return PORT_ERR_UNKNOWN;

--- a/spi.c
+++ b/spi.c
@@ -84,7 +84,7 @@ static port_err_t spi_open(struct port_interface *port,
   /* 3. configure the SPI device */
   h->mode = SPI_MODE_0;
   h->bits = 8;
-  h->speed = 500000; // 500 kHz
+  h->speed = 8000000; // (8 MHz)
   h->initialized = false;
 
   ret = ioctl(fd, SPI_IOC_WR_MODE, &h->mode);
@@ -241,7 +241,7 @@ static const char *spi_get_cfg_str(struct port_interface *port) {
 	if (h == NULL)
 		return "INVALID";
 
-	snprintf(str, sizeof(str), "speed %d kHz, spi mode %d, %d bits per word", h->speed / 1000, h->mode, h->bits);
+	snprintf(str, sizeof(str), "speed %d MHz, spi mode %d, %d bits per word", h->speed / 1000000, h->mode, h->bits);
 	return str;
 }
 

--- a/spi.c
+++ b/spi.c
@@ -231,7 +231,15 @@ static port_err_t spi_gpio(struct port_interface __unused *port,
 }
 
 static const char *spi_get_cfg_str(struct port_interface *port) {
-  return "NO CONFIG";
+	struct spi_priv *h;
+	static char str[100];
+
+	h = (struct spi_priv *)port->private;
+	if (h == NULL)
+		return "INVALID";
+
+	snprintf(str, sizeof(str), "speed %d kHz, spi mode %d, %d bits per word", h->speed / 1000, h->mode, h->bits);
+	return str;
 }
 
 static struct varlen_cmd spi_cmd_get_reply[] = {
@@ -247,7 +255,7 @@ static port_err_t spi_flush(struct port_interface __unused *port) {
 
 struct port_interface port_spi = {
   .name	= "spi",
-  .flags	= PORT_SPI_INIT | PORT_CMD_SOF,
+  .flags	= PORT_SPI_INIT | PORT_CMD_SOF | PORT_RETRY,
   .open	= spi_open,
   .close	= spi_close,
   .flush  = spi_flush,

--- a/stm32.c
+++ b/stm32.c
@@ -31,7 +31,6 @@
 
 #define STM32_ACK	0x79
 #define STM32_NACK	0x1F
-#define STM32_ACKOK	0x79
 #define STM32_BUSY	0x76
 #define STM32_BUSY2	0xA5
 

--- a/stm32.c
+++ b/stm32.c
@@ -223,8 +223,7 @@ static stm32_err_t stm32_get_ack_timeout(const stm32_t *stm, time_t timeout)
 			return (byte == STM32_ACK) ? STM32_ERR_OK : STM32_ERR_NACK;
 		}
 		if (byte != STM32_BUSY) {
-			fprintf(stderr, "Got byte 0x%02x instead of ACK\n",
-				byte);
+			fprintf(stderr, "Got byte 0x%02x instead of ACK\n", byte);
 			return STM32_ERR_UNKNOWN;
 		}
 	} while (1);

--- a/stm32.c
+++ b/stm32.c
@@ -460,7 +460,6 @@ stm32_t *stm32_init(struct port_interface *port, const char init)
 			return NULL;
 
 	/* get the version and read protection status  */
-		fprintf(stderr, "send gvr\n");
 	if (stm32_send_command(stm, STM32_CMD_GVR) != STM32_ERR_OK) {
 		stm32_close(stm);
 		return NULL;

--- a/stm32.c
+++ b/stm32.c
@@ -213,10 +213,10 @@ static stm32_err_t stm32_get_ack_timeout(const stm32_t *stm, time_t timeout)
 
 		if (byte == STM32_ACK || byte == STM32_NACK) {
 			if (port->flags & PORT_SPI_INIT) {
-				byte = STM32_ACKOK;
+				byte = STM32_ACK;
 				p_err = port->write(port, &byte, 1);
 		    	if (p_err != PORT_ERR_OK) {
-			    	fprintf(stderr, "Failed to write ACKOK byte\n");
+			    	fprintf(stderr, "Failed to reply ACK byte\n");
 			    	return STM32_ERR_UNKNOWN;
 		    	}
 			}
@@ -358,7 +358,7 @@ static stm32_err_t stm32_guess_len_cmd(const stm32_t *stm, uint8_t cmd,
 			return STM32_ERR_UNKNOWN;
 	}
 
-	fprintf(stderr, "Re sync (len = %d)\n", data[0]);
+	fprintf(stderr, "Resync (len = %d)\n", data[0]);
 	if (stm32_resync(stm) != STM32_ERR_OK)
 		return STM32_ERR_UNKNOWN;
 
@@ -398,10 +398,10 @@ static stm32_err_t stm32_send_init_seq(const stm32_t *stm)
 	p_err = port->read(port, &byte, 1);
 	if (p_err == PORT_ERR_OK && (byte == STM32_ACK || byte == STM32_NACK)) {
 		if (port->flags & PORT_SPI_INIT) {
-			byte = STM32_ACKOK;
+			byte = STM32_ACK;
 			p_err = port->write(port, &byte, 1);
 		    if (p_err != PORT_ERR_OK) {
-		    	fprintf(stderr, "Failed to write ACKOK byte\n");
+		    	fprintf(stderr, "Failed to reply ACK byte\n");
 		    	return STM32_ERR_UNKNOWN;
 	    	}
 		}
@@ -409,12 +409,12 @@ static stm32_err_t stm32_send_init_seq(const stm32_t *stm)
 			return STM32_ERR_OK;
 		} else {
 			/* We could get error later, but let's continue, for now. */
-			fprintf(stderr, "Warning: the interface was not closed properly.\n");
+			fprintf(stderr, "Warning: The interface was not closed properly\n");
 			return STM32_ERR_OK;
 		}
 	}
 	if (p_err != PORT_ERR_TIMEDOUT) {
-		fprintf(stderr, "Failed to init device.\n");
+		fprintf(stderr, "Failed to init device\n");
 		return STM32_ERR_UNKNOWN;
 	}
 
@@ -422,17 +422,16 @@ static stm32_err_t stm32_send_init_seq(const stm32_t *stm)
 	 * Check if previous STM32_CMD_UART_INIT / STM32_CMD_SPI_INIT was
 	 * taken as first byte of a command. Send a new byte, we should
 	 * get back a NACK.
-	 * TODO: Test this with SPI
 	 */
 	p_err = port->write(port, &cmd, 1);
 	if (p_err != PORT_ERR_OK) {
-		fprintf(stderr, "Failed to send init to device\n");
+		fprintf(stderr, "Failed to send init to device while resetting\n");
 		return STM32_ERR_UNKNOWN;
 	}
 	p_err = port->read(port, &byte, 1);
 	if (p_err == PORT_ERR_OK && byte == STM32_NACK)
 		return STM32_ERR_OK;
-	fprintf(stderr, "Failed to init device.\n");
+	fprintf(stderr, "Failed to reset device\n");
 	return STM32_ERR_UNKNOWN;
 }
 

--- a/stm32.c
+++ b/stm32.c
@@ -204,9 +204,7 @@ static stm32_err_t stm32_get_ack_timeout(const stm32_t *stm, time_t timeout)
 		p_err = port->read(port, &byte, 1);
 		if (timeout) {
 			time(&t1);
-			if (t1 < t0 + timeout)
-				continue;
-			else {
+			if (!(t1 < t0 + timeout)) {
 				fprintf(stderr, "Timeout while waiting for ACK\n");
 				return STM32_ERR_UNKNOWN;
 			}
@@ -462,12 +460,16 @@ stm32_t *stm32_init(struct port_interface *port, const char init)
 			return NULL;
 
 	/* get the version and read protection status  */
+		fprintf(stderr, "send gvr\n");
 	if (stm32_send_command(stm, STM32_CMD_GVR) != STM32_ERR_OK) {
 		stm32_close(stm);
 		return NULL;
 	}
 
 	/* From AN, only UART bootloader returns 3 bytes */
+
+	// TODO: This fails on SPI (because of dummy read missing?)
+
 	len = (port->flags & PORT_GVR_ETX) ? 3 : 1;
 	if (port->read(port, buf, len) != PORT_ERR_OK)
 		return NULL;

--- a/stm32flash.1
+++ b/stm32flash.1
@@ -1,6 +1,6 @@
 .TH STM32FLASH 1 "2015\-11\-25" STM32FLASH "User command"
 .SH NAME
-stm32flash \- flashing utility for STM32 through UART or I2C
+stm32flash \- flashing utility for STM32 through UART, I2C or SPI
 .SH SYNOPSIS
 .B stm32flash
 .RB [ \-cfhjkouvCR ]
@@ -30,19 +30,23 @@ stm32flash \- flashing utility for STM32 through UART or I2C
 .IR GPIO_string ]
 .RI [ tty_device
 |
-.IR i2c_device ]
+.IR i2c_device
+|
+.IR spi_device ]
 
 .SH DESCRIPTION
 .B stm32flash
 reads or writes the flash memory of STM32.
 
 It requires the STM32 to embed a bootloader compliant with ST
-application note AN3155 or AN4221.
+application note AN3155, AN4221 or AN4286.
 .B stm32flash
 uses the serial port
 .I tty_device
-or the i2c port
+, the i2c port
 .I i2c_device
+or the spi port
+.I spi_device
 to interact with the bootloader of STM32.
 
 .SH OPTIONS
@@ -245,7 +249,7 @@ the '&' delimiter adds no delay.
 An empty signal, thus repeated ',' delimiters, can be used to insert larger
 delays in multiples of 100 ms.
 E.g. "rts,,,,\-dtr" will set RTS, then wait 400 ms, then reset DTR.
-"rts&\-dtr" will set RTS and reset DTR without delay. You can use ',' delimiters 
+"rts&\-dtr" will set RTS and reset DTR without delay. You can use ',' delimiters
 alone to simply add a delay between opening port and starting to flash.
 .DP
 .P
@@ -374,6 +378,9 @@ and is since 2012 maintained by
 Man page and extension to STM32W and I2C are written by
 .IR "Antonio Borneo <borneo.antonio@gmail.com>" .
 
+SPI extension is written by
+.IR "Nils Hasenbanck <nils@hasenbanck.de>" .
+
 Please report any bugs at the project homepage
 http://stm32flash.sourceforge.net .
 
@@ -386,8 +393,10 @@ The current version of
 .B stm32flash
 only supports
 .I UART
-and
+,
 .I I2C
+and
+.I SPI
 ports.
 .PD 0
 .P


### PR DESCRIPTION
Implements flashing over SPI. Tested on a STM32F722ZE. Speed improvement over flashing with I2C is around 24x.

Changes:
 * Implements SPI backend
 * Improves flashing logic to handle edge cases of SPI protocoll
 * Timeout improvements
 * Added help / man information
 * Added Author
 * Increased version number